### PR TITLE
Add attribution to the PNG filename

### DIFF
--- a/ClientApp/src/graph/Png.tsx
+++ b/ClientApp/src/graph/Png.tsx
@@ -60,7 +60,7 @@ export function saveAsPng(graph: Graph, screenName: string, stroke: boolean) {
   });
 
   const downloadLink = document.createElement('a');
-  downloadLink.setAttribute('download', `${screenName}.png`);
+  downloadLink.setAttribute('download', `furland_${screenName}.png`);
   const dataURL = canvas.toDataURL('image/png');
   downloadLink.setAttribute('href', dataURL);
   downloadLink.click();


### PR DESCRIPTION
I imagine people will be sharing their graphs as PNGs without linking back to the original project (out of laziness, not malice), so having the name of the project be a part of the default PNG filename would be helpful for those wondering where the graph originated from. It's also more descriptive in your downloads folder than just your username, which could be anything really.